### PR TITLE
Keep resolved url

### DIFF
--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -28,7 +28,7 @@ export function parseContentRange(contentRange: string): IContentRangeType {
 /**
  * Simple HTTP-client, which both works in node.js and browser
  */
-export class HttpClient implements IRangeRequestClient {
+export class HttpClient implements IHttpClient {
 
   private static getContentLength(headers: _fetch.Headers): number {
     const contentLength = headers.get('Content-Length');

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -1,6 +1,7 @@
 import * as initDebug from 'debug';
 import * as _fetch from 'node-fetch';
-import { IRangeRequestClient, IContentRangeType, IHeadRequestInfo, IRangeRequestResponse } from '@tokenizer/range'; // Add 'fetch' API for node.js
+import { IContentRangeType, IHeadRequestInfo, IRangeRequestResponse } from '@tokenizer/range'; // Add 'fetch' API for node.js
+import { IHttpClient } from './types';
 
 const debug = initDebug('streaming-http-token-reader:http-client');
 
@@ -50,6 +51,8 @@ export class HttpClient implements IHttpClient {
       arrayBuffer: () => resp.arrayBuffer()
     };
   }
+
+  public resolvedUrl: string;
 
   constructor(private url: string) {
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,10 +14,6 @@ export interface IHttpResponse extends IHeadInfo {
   arrayBuffer: () => Promise<Buffer>;
 }
 
-export interface IHttpClient {
+export interface IHttpClient extends IRangeRequestClient {
   resolvedUrl?: string;
-
-  getHeadInfo?(): Promise<IHeadInfo>;
-
-  getResponse(method: string, range?: [number, number]): Promise<IHttpResponse>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,7 @@ export interface IHttpResponse extends IHeadInfo {
 }
 
 export interface IHttpClient {
+  resolvedUrl?: string;
 
   getHeadInfo?(): Promise<IHeadInfo>;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import { IRangeRequestClient } from '@tokenizer/range';
+
 export interface IContentRangeType {
   firstBytePosition?: number;
   lastBytePosition?: number;


### PR DESCRIPTION
When fetching a url, store the resolved url for later use. This is done, for example, when a user provides a url that redirects. We store the resulting url (after following the redirect), so that it doesn't need to follow the redirect each time we make a request. Thus, this change improves performance when dealing with redirects.

---

@Borewit This is what I assumed would fix #117 

Also related to this, where is `tokenizer.fileInfo.url` used? It appears this `rangeRequestClient` (ie. this library) doesn't use that.