### PR TITLE
Make the url resolving configurable

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,14 +1,19 @@
-import { HttpClient } from './http-client';
+import { HttpClient, HttpClientConfig } from './http-client';
 import * as rangeTokenizer from '@tokenizer/range';
 import { ITokenizer } from 'strtok3/lib/core';
 
 /**
  * Create and initialize the HTTP tokenizer
  * @param url URL to resource to stream with tokenizer
- * @param config Configuration options
+ * @param tokenizerConfig Tokenizer configuration options
+ * @param httpClientConfig HTTP client configuration options
  * @return Tokenizer
  */
-export function makeTokenizer(url: string, config?: rangeTokenizer.IRangeRequestConfig): Promise<ITokenizer> {
-  const httpClient = new HttpClient(url);
-  return rangeTokenizer.tokenizer(httpClient, config);
+export function makeTokenizer(
+  url: string,
+  tokenizerConfig?: rangeTokenizer.IRangeRequestConfig,
+  httpClientConfig?: HttpClientConfig
+): Promise<ITokenizer> {
+  const httpClient = new HttpClient(url, httpClientConfig);
+  return rangeTokenizer.tokenizer(httpClient, tokenizerConfig);
 }


### PR DESCRIPTION
Hey @Borewit 👋
I hope you're doing well. 

This isn't urgent at all, so for whenever you can get to this.

I noticed a few edge cases with the url resolving, so I figured that it'd be better to make this optional (ie. configurable). In my case specifically, I had a service worker that acted on a specific type of url. What happened was that the tokenizer here cached the resolved url, which normally would be great, but now the service worker was skipped. So this caused an issue in my code, because I don't know about the resolved url in my service worker.

Anyhow long story short, after some thought, I think it's better to make this optional.