### PR TITLE
fix: Add missing range header in getResponse

### DIFF
--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -44,6 +44,7 @@ export class HttpClient implements IRangeRequestClient {
     }
 
     const headers = new Headers();
+    headers.set('Range', 'bytes=' + range[0] + '-' + range[1]);
 
     const response = new ResponseInfo(await fetch(this.resolvedUrl || this.url, {method, headers, signal: this.abortController.signal}));
     if (response.response.ok) {


### PR DESCRIPTION
Hi @Borewit 👋 I noticed the range header was missing from the GET requests, this PR should fix that.

Thanks for all the updates to music-metadata! 🙏 